### PR TITLE
fix: correct sucessfully->successfully typo in notification titles

### DIFF
--- a/main.js
+++ b/main.js
@@ -275,7 +275,7 @@ async function convert(filepath) {
       if (code === 0) {
         console.log("Converted successfully.");
         showNotification({
-          title: "Markdown converted sucessfully",
+          title: "Markdown converted successfully",
           body: "Exported document saved in " + getOutputDirectory(filepath),
         });
         shell.showItemInFolder(
@@ -434,7 +434,7 @@ async function externalConvert(filepath) {
               } else {
                 console.log("Completed!");
                 showNotification({
-                  title: "Markdown converted sucessfully",
+                  title: "Markdown converted successfully",
                   body:
                     "Exported document saved in " + getOutputDirectory(filepath),
                 });


### PR DESCRIPTION
Corrects 'sucessfully' to 'successfully' in 2 user-facing desktop notification titles (main.js lines 278, 437). 

User-facing: shown in system notifications when markdown export succeeds.

**Changes:**
- `sucessfully` → `successfully` (2 instances in notification title strings)